### PR TITLE
Fix curve radius scale on Blender 4.5

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -137,7 +137,7 @@ def create_line_depth_geometry_nodes(filename, material):
     curve_to_mesh = threadgeometrynodes.nodes.new("GeometryNodeCurveToMesh")
     curve_to_mesh.name = "Curve to Mesh"
     # Fill Caps
-    curve_to_mesh.inputs[2].default_value = False
+    curve_to_mesh.inputs[3].default_value = False
     # node Curve Circle
     curve_circle = threadgeometrynodes.nodes.new("GeometryNodeCurvePrimitiveCircle")
     curve_circle.name = "Curve Circle"


### PR DESCRIPTION
In Blender 4.5, The curve to mesh node have a new input added : scale which is in the 2nd position, and the fill caps is now on 3rd position.

![image](https://github.com/user-attachments/assets/9764caec-1405-434f-bef2-0bff380c695e)

Because the script was setting input[2] to False, it would result to a scale of 0 in blender 4.5 which make the curves comletely invisible.

This change is not completely future proof, as it would make older blender version not compatible. I don't know if you want to support older version of blender, but if do, and are curious you can have a look at this small file which have a BVERSION float contant in it

https://github.com/Tilapiatsu/blender-Universal_Multi_Importer/blob/979e7a1f5a17fce2fecb67c1ed79ee0e3123cf24/bversion/blender_version.py

Then you can in your code:
```
from blender_version import BVERSION

if BVERSION >= 4.5:
    curve_to_mesh.inputs[3].default_value = False
else:
    curve_to_mesh.inputs[2].default_value = False
```